### PR TITLE
add static getindex for tuple

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StaticRanges"
 uuid = "d8176aec-3168-11e9-3c98-e3954798be3a"
 authors = ["zchristensen "]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/StaticRanges.jl
+++ b/src/StaticRanges.jl
@@ -150,6 +150,11 @@ for R in (MutableRange, StaticRange)
     end
 end
 
+@generated function Base.getindex(t::Tuple, ::StaticRange{<:Any, sr}) where {sr} 
+    Expr(:tuple, (:(t[$i]) for i ∈ sr)...)
+end
+                    
+                    
 Base.intersect(r::StaticRange, s::MutableRange) = intersect(parent(r), s)
 Base.intersect(r::MutableRange, s::StaticRange) = intersect(r, parent(s))
 #intersect(r::MutableRange, s::AbstractRange) in StaticRanges at /Users/zchristensen/projects/StaticRanges.jl/src/StaticRanges.jl:137,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -819,6 +819,11 @@ if VERSION > v"1.6" && sizeof(Int) === 8
 end
 include("count_tests.jl")
 
+@testset "Tuple getindex on static range" begin
+    f(t) = t[StaticRange(1:2:end-1)] .+ t[StaticRange(2:2:end)]
+    @test @inferred f((1,2,3,4,5,6)) == (3, 7, 11)
+end
+
 #=
 #@test 1.0:(.3-.1)/.1 == 1.0:2.0
 =#


### PR DESCRIPTION
Without a static range:
```julia
julia> f(t) = t[1:2:end] .+ t[2:2:end]
f (generic function with 1 method)

julia> @code_warntype f((1,2,3,4))
MethodInstance for f(::NTuple{4, Int64})
  from f(t) in Main at REPL[29]:1
Arguments
  #self#::Core.Const(f)
  t::NTuple{4, Int64}
Body::Any
1 ─ %1 = Base.lastindex(t)::Core.Const(4)
│   %2 = (1:2:%1)::Core.Const(1:2:3)
│   %3 = Base.getindex(t, %2)::Tuple{Vararg{Int64}}
│   %4 = Base.lastindex(t)::Core.Const(4)
│   %5 = (2:2:%4)::Core.Const(2:2:4)
│   %6 = Base.getindex(t, %5)::Tuple{Vararg{Int64}}
│   %7 = Base.broadcasted(Main.:+, %3, %6)::Base.Broadcast.Broadcasted{Base.Broadcast.Style{Tuple}, Nothing, typeof(+)}
│   %8 = Base.materialize(%7)::Any
└──      return %8
```

With a static range and this PR:
```julia
julia> using StaticRanges

julia> @generated function Base.getindex(t::Tuple, ::StaticRange{<:Any, sr}) where {sr} 
           Expr(:tuple, (:(t[$i]) for i ∈ sr)...)
       end

julia> f(t::Tuple) = t[StaticRange(1:2:end)] .+ t[StaticRange(2:2:end)]
f (generic function with 2 methods)

julia> @code_warntype f((1,2,3,4))
MethodInstance for f(::NTuple{4, Int64})
  from f(t::Tuple) in Main at REPL[25]:1
Arguments
  #self#::Core.Const(f)
  t::NTuple{4, Int64}
Body::Tuple{Int64, Int64}
1 ─ %1  = Base.lastindex(t)::Core.Const(4)
│   %2  = (1:2:%1)::Core.Const(1:2:3)
│   %3  = Main.StaticRange(%2)::Core.Const(static(1:2:3))
│   %4  = Base.getindex(t, %3)::Tuple{Int64, Int64}
│   %5  = Base.lastindex(t)::Core.Const(4)
│   %6  = (2:2:%5)::Core.Const(2:2:4)
│   %7  = Main.StaticRange(%6)::Core.Const(static(2:2:4))
│   %8  = Base.getindex(t, %7)::Tuple{Int64, Int64}
│   %9  = Base.broadcasted(Main.:+, %4, %8)::Base.Broadcast.Broadcasted{Base.Broadcast.Style{Tuple}, Nothing, typeof(+), Tuple{Tuple{Int64, Int64}, Tuple{Int64, Int64}}}
│   %10 = Base.materialize(%9)::Tuple{Int64, Int64}
└──       return %10
```